### PR TITLE
Documentation improvements: add docstrings and fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ send the differential equation over to Python and solve it.
 Note that this package isn't for production use and is mostly just for benchmarking
 and helping new users migrate models over to Julia.
 For more efficient solvers, see the
-[DifferentialEquations.jl documentation](https://github.com/JuliaDiffEq/DifferentialEquations.jl).
+[DifferentialEquations.jl documentation](https://docs.sciml.ai/DiffEqDocs/stable/).
 
 ## Installation
 
@@ -83,7 +83,7 @@ import timeit
 import numba
 def f(u, t):
     x, y, z = u
-    return [10.0 * (y - x), x * (28.0 - z) - y, x * y - 2.66 * z]
+    return [10.0 * (y - x), x * (28.0 - z) - y, x * y - (8.0/3.0) * z]
 
 u0 = [1.0,0.0,0.0]
 tspan = (0., 100.)
@@ -118,7 +118,7 @@ import timeit
 import numba
 def f(t,u):
     x, y, z = u
-    return [10.0 * (y - x), x * (28.0 - z) - y, x * y - 2.66 * z]
+    return [10.0 * (y - x), x * (28.0 - z) - y, x * y - (8.0/3.0) * z]
 
 u0 = [1.0,0.0,0.0]
 tspan = (0.0, 100.0)

--- a/src/SciPyDiffEq.jl
+++ b/src/SciPyDiffEq.jl
@@ -6,12 +6,72 @@ using DiffEqBase: ReturnCode
 using PyCall
 using PrecompileTools
 
+"""
+    SciPyAlgorithm
+
+Abstract supertype for all SciPy ODE solver algorithms.
+"""
 abstract type SciPyAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
+
+"""
+    RK45()
+
+Explicit Runge-Kutta method of order 5(4) from SciPy. This is the Dormand-Prince
+method, suitable for non-stiff problems.
+
+See also: [`RK23`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
+"""
 struct RK45 <: SciPyAlgorithm end
+
+"""
+    RK23()
+
+Explicit Runge-Kutta method of order 3(2) from SciPy. Suitable for non-stiff
+problems with lower accuracy requirements.
+
+See also: [`RK45`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
+"""
 struct RK23 <: SciPyAlgorithm end
+
+"""
+    Radau()
+
+Implicit Runge-Kutta method of the Radau IIA family of order 5 from SciPy.
+Suitable for stiff problems.
+
+See also: [`RK45`](@ref), [`RK23`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
+"""
 struct Radau <: SciPyAlgorithm end
+
+"""
+    BDF()
+
+Implicit multi-step variable-order (1 to 5) method based on backward
+differentiation formulas from SciPy. Suitable for stiff problems.
+
+See also: [`RK45`](@ref), [`RK23`](@ref), [`Radau`](@ref), [`LSODA`](@ref)
+"""
 struct BDF <: SciPyAlgorithm end
+
+"""
+    LSODA()
+
+Adams/BDF method with automatic stiffness detection and switching from SciPy.
+Originally from the FORTRAN library ODEPACK.
+
+See also: [`RK45`](@ref), [`RK23`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`odeint`](@ref)
+"""
 struct LSODA <: SciPyAlgorithm end
+
+"""
+    odeint()
+
+SciPy's `odeint` function, which wraps the FORTRAN solver LSODA from ODEPACK.
+This is the legacy SciPy interface. Note that `saveat` is required when using
+this algorithm.
+
+See also: [`LSODA`](@ref), [`RK45`](@ref), [`BDF`](@ref)
+"""
 struct odeint <: SciPyAlgorithm end
 
 const integrate = PyNULL()


### PR DESCRIPTION
## Summary
- Add docstrings for all exported algorithm types (RK45, RK23, Radau, BDF, LSODA, odeint) explaining their purpose and when to use them
- Update DifferentialEquations.jl link to use current SciML documentation URL instead of outdated GitHub link
- Fix Python benchmark examples to use correct Lorenz parameter `8.0/3.0` instead of approximate value `2.66`, matching the Julia examples

## Test plan
- [x] Verified all package tests pass with `Pkg.test()`
- [x] Verified README example works correctly
- [x] Verified docstrings are accessible via `@doc`

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)