### PR TITLE
Documentation improvements: Fix URLs and add clarity notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ using Pkg
 Pkg.add("SciPyDiffEq")
 ```
 
+The package will automatically install SciPy via Conda.jl on first use if it's not already available.
+
 ## Using SciPyDiffEq.jl
 
-SciPyDiffEq.jl is simply a solver on the DiffEq common interface, so for details see the [DifferentialEquations.jl documentation](https://diffeq.sciml.ai/dev/).
+SciPyDiffEq.jl is simply a solver on the DiffEq common interface, so for details see the [DifferentialEquations.jl documentation](https://docs.sciml.ai/DiffEqDocs/stable/).
 The available algorithms are:
 
 ```julia
@@ -152,6 +154,11 @@ benchmarks are gone because any measurement here is accelerating SciPy more
 than standard accelerated use.
 
 ## Benchmarks
+
+**Note:** The following benchmark examples use deprecated APIs (`@ode_def_bare`, `@ode_def`)
+that are no longer available in current versions of DifferentialEquations.jl.
+For modern benchmarking code, please refer to the
+[SciMLBenchmarks.jl repository](https://github.com/SciML/SciMLBenchmarks.jl).
 
 The following benchmarks demonstrate a **50x-1,000x performance advantage for the
 pure-Julia methods over the Julia-accelerated (3x) SciPy ODE solvers** across


### PR DESCRIPTION
## Summary

This PR improves the README documentation with several targeted fixes:

- **Fix documentation URL consistency**: Changed `diffeq.sciml.ai/dev/` to `docs.sciml.ai/DiffEqDocs/stable/` to match the URL used elsewhere in the README
- **Add installation note**: Clarified that SciPy will be automatically installed via Conda.jl on first use
- **Add deprecation warning**: Added a clear note that the benchmark examples use deprecated `@ode_def_bare` and `@ode_def` APIs that no longer work in modern DifferentialEquations.jl, with a link to SciMLBenchmarks.jl for current benchmarking code

## Test Plan

- [x] Verified the basic example still works correctly
- [x] Ran full test suite (`Pkg.test()`) - all tests pass
- [x] Checked that documentation changes are accurate

These changes help users understand installation requirements and avoid confusion from deprecated benchmark code examples.

cc: @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)