### PR TITLE
Fix minimum version bounds for DiffEqBase and PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 CommonSolve = "0.2.6"
-DiffEqBase = "6"
+DiffEqBase = "6.174"
 ExplicitImports = "1.14.0"
-PrecompileTools = "1"
+PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
 SciMLBase = "2.131.0"


### PR DESCRIPTION
@ChrisRackauckas 

## Problem
The current minimum version bounds were too low and incompatible with `SciMLBase 2.131.0`:
- `DiffEqBase = "6"` (6.0.0) was incompatible with SciMLBase 2.131.0
- `PrecompileTools = "1"` (1.0.0) was incompatible with SciMLBase 2.131.0

## Root Cause Analysis
`DiffEqBase 6.0.0` has dependencies that conflict with `SciMLBase 2.131.0`:

1. **RecipesBase conflict**: DiffEqBase 6.0.0 requires RecipesBase 0.4-0.7, but SciMLBase 2.131.0 requires RecipesBase 1.3.4
2. **RecursiveArrayTools conflict**: DiffEqBase 6.0.0-6.151 requires RecursiveArrayTools 2.x, but SciMLBase 2.131.0 requires RecursiveArrayTools 3.35+
3. **SciMLOperators conflict**: DiffEqBase 6.0.0-6.173 requires SciMLOperators 0.2-0.3, but SciMLBase 2.131.0 requires SciMLOperators 1.3+
4. **PrecompileTools conflict**: PrecompileTools 1.0.0 is incompatible with SciMLBase 2.131.0, which requires PrecompileTools 1.2.0+

## Solution
Updated minimum version bounds based on registry compatibility analysis:

### DiffEqBase: `"6"` → `"6.174"`
- v6.174 is the first version supporting SciMLOperators 1.x (alongside 0.3-0.4)
- v6.152+ supports RecursiveArrayTools 3.x
- v6.26+ supports RecipesBase 1.x
- v6.174 satisfies all three requirements simultaneously

### PrecompileTools: `"1"` → `"1.2"`
- v1.2.0 is required for compatibility with SciMLBase 2.131.0

## Testing
Verified that the package resolver can successfully install all dependencies with these new minimum bounds. The tests themselves may fail due to Python/scipy environment setup issues, but the Julia package compatibility is correct.

## Changes
- `Project.toml`: Updated `DiffEqBase = "6.174"` and `PrecompileTools = "1.2"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)