### PR TITLE
Bump SciMLBase compat to v3 and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciPyDiffEq"
 uuid = "505e40e9-d84e-434c-8501-7161967c02cb"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -18,7 +18,7 @@ ExplicitImports = "1.14.0"
 PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
-SciMLBase = "2.131.0"
+SciMLBase = "2.131.0, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary
- Update SciMLBase compat bounds to include v3
- Bump package version (minor): 0.2.4 → 0.3.0
- No code changes needed - package doesn't use deprecated SciMLBase v2 patterns
- Supersedes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)