### PR TITLE
Expand SciMLBase compat to v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ ExplicitImports = "1.14.0"
 PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
-SciMLBase = "2.131.0"
+SciMLBase = "2.131.0, 3"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
## Summary
Supersedes #49 with a version that is verified not to need source/test changes for SciMLBase v3.

SciPyDiffEq wraps SciPy's integrator and does not rely on any of the APIs removed in SciMLBase v3:
- No integer indexing of `ODESolution` (the `sol` in the wrapper is a Python object, accessed via string keys like `sol[\"t\"]`, `sol[\"y\"]`).
- No use of removed deprecated symbols (`DESolution`, `DEProblem`, `DEAlgorithm`, `TimeChoiceIterator`, `u_modified!`, `.destats`, etc.).
- `DiffEqBase.build_solution` / `LinearInterpolation` / `AbstractDiffEqInterpolation` are unchanged.

So the only change needed is to expand the compat bound.

## Test plan
- [ ] CI passes.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)