### PR TITLE
Widen DiffEqBase compat to v7 (finish v7 ecosystem migration)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciPyDiffEq"
 uuid = "505e40e9-d84e-434c-8501-7161967c02cb"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -13,7 +13,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 CommonSolve = "0.2.6"
-DiffEqBase = "6.174"
+DiffEqBase = "6.174, 7"
 ExplicitImports = "1.14.0"
 PrecompileTools = "1.2"
 PyCall = "1.91"


### PR DESCRIPTION
## Summary

Widens `DiffEqBase` compat from `6.174` to `6.174, 7` so SciPyDiffEq
resolves against the new OrdinaryDiffEq v7 / SciMLBase v3 /
RecursiveArrayTools v4 ecosystem, and bumps the patch version to `0.2.6`.

SciMLBase compat was already widened to `2.131.0, 3` on master
(commit `bf69f10`), so the only remaining outstanding piece was
DiffEqBase — which is what Dependabot PR #53 opened to do.

## Relationship to Dependabot PR #53

PR #53 makes the same one-line compat change Dependabot-style but is
titled as a "requirement" bump from `6.174` → `6.174, 7.0` and does
not document the code-level audit. This PR does the same compat bump
**plus** documents the audit against every v7 breaking-change category,
so reviewers can merge with confidence that SciPyDiffEq really does
not need any code changes. PR #53 can be closed in favor of this one
(or whichever the maintainer prefers).

## Audit of v7 breaking-change categories — no hits

I grepped `src/` and `test/` against the full migration checklist
from the OrdinaryDiffEq v7 breaking-changes document and found that
SciPyDiffEq does not use any of the removed or renamed APIs:

### SciMLBase v3 renames (none used)
- `u_modified!` / `integrator.u_modified` — not used
- `DEAlgorithm` / `DEProblem` / `DESolution` — not used
  (grep matches `AbstractODEAlgorithm`, `AbstractODEProblem`, `ODEProblem`,
  none of which were renamed)
- `sol.destats` / `has_destats` — not used
- `symbol_to_ReturnCode` — not used; the wrapper already constructs
  `ReturnCode.Success` / `ReturnCode.Failure` directly
- `syms` / `paramsyms` / `indepsym` kwargs — not used
- `sol.x` / `prob.lb` / `prob.ub` / `sol.minimizer` / `sol.minimum` — not used
- `tuples()` / `intervals()` / `IntegratorTuples` / `IntegratorIntervals`
  / `TimeChoiceIterator` — not used
- `QuadratureProblem` / `EnsembleProblem(vec)` / `IntegralProblem nout/batch` — not used

### DiffEqBase v7 removals (none used)
- `has_destats` / `RECOMPILE_BY_DEFAULT` / `fastpow` / `DEStats`
  / `concrete_solve` — not used

### RecursiveArrayTools v4 (AbstractVectorOfArray now <: AbstractArray)
- `sol[i]` / `length(sol)` / `eachindex(sol)` / `iterate(sol)`
  / `first(sol)` / `last(sol)` / `map(f, sol)` / `maximum(sol)` — not used
  SciPyDiffEq constructs a fresh `timeseries::Vector` from the
  PyCall-returned `sol["y"]` and never indexes an `ODESolution`.
  The returned solution is passed back to the caller via
  `DiffEqBase.build_solution`, so the wrapper itself is agnostic to
  `ODESolution` indexing semantics.

### Bool kwargs banned in v7 (none used)
- `verbose` / `autodiff` / `lazy` / `alias_u0` / `alias_du0` / `alias` — not used
  (the `solve` method accepts `dense`, `dt`, `dtmax`, `dtmin`,
  `save_everystep`, `saveat`, `timeseries_errors`, `reltol`, `abstol`,
  `maxiters`, plus `kwargs...`, and forwards none of these to any
  v7 solver since it calls `scipy.integrate`).

### Algorithm struct changes (none affected)
- No `{CS, AD, FDT, ST, CJ}` type parameters in the `SciPyAlgorithm`
  hierarchy
- No `chunk_size` / `diff_type` / `standardtag` / `precs` / per-algorithm
  `controller` kwargs

### Controller refactor (none affected)
- No `gamma` / `beta1` / `beta2` / `qmin` / `qmax` / `qsteady_min`
  / `qsteady_max` / `qoldinit` kwargs
- No `integrator.EEst` / `qold` / `q11` / `erracc` / `dtacc` / `q`
  field accesses

### Ensemble signature changes (none affected)
- No `prob_func(prob, i, repeat)` / `output_func(sol, i)` signatures

### Package scope reduction (N/A)
- SciPyDiffEq does not `using OrdinaryDiffEq` in `src/` or `test/`, so
  the new reduced default export set and the family-sublib split
  do not affect it.

### Tableau renames (none used)
- No `construct*` tableau function calls

### Default changes (none affect SciPyDiffEq's tests)
- `CheckInit` DAE default, `ODEFunction` specialization, low-storage
  RK `williamson_condition` default — none of these apply to a
  wrapper that delegates time integration to SciPy.

## Files changed

- `Project.toml`: `DiffEqBase = "6.174"` → `DiffEqBase = "6.174, 7"`,
  version `0.2.5` → `0.2.6`

## Test results

Local `Pkg.test()` on Julia 1.12.4 against the resolved v7 environment:

```
  [2b5f629d] DiffEqBase v7.0.0
  [731186ca] RecursiveArrayTools v4.2.0
  [0bca4576] SciMLBase v3.4.2
  [505e40e9] SciPyDiffEq v0.2.6
```

```
Test Summary:   | Pass  Total   Time
ExplicitImports |    2      2  22.9s
Test Summary: | Pass  Total   Time
SciPy Solvers |   12     12  14.4s
Test Summary:                    | Pass  Total  Time
odeint retcode with dense saveat |    1      1   0.6s
     Testing SciPyDiffEq tests passed
```

All 15 / 15 tests pass.

Command used (from the repo root):
```
julia --project=. -e 'using Pkg; Pkg.test()'
```

## Test plan

- [x] `Pkg.resolve()` resolves DiffEqBase v7 / SciMLBase v3 / RAT v4
- [x] `Pkg.test()` on Julia 1.12 against v7 env passes 15/15
- [ ] CI runs across Julia matrix