### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,18 +11,5 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-        version:
-          - '1'
-          - 'lts'
-          - 'pre'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,11 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
+Aqua = "0.8"
 CommonSolve = "0.2.6"
 DiffEqBase = "6.174, 7"
 ExplicitImports = "1.14.0"
+JET = "0.9,0.10,0.11"
 PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
@@ -23,8 +25,10 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ExplicitImports", "Test"]
+test = ["Aqua", "ExplicitImports", "JET", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
 SciMLBase = "2.131.0, 3"
+Test = "1"
 julia = "1.10"
 
 [extras]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SciPyDiffEq = "505e40e9-d84e-434c-8501-7161967c02cb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+SciPyDiffEq = { path = "../.." }
+
+[compat]
+Aqua = "0.8"
+JET = "0.9,0.10,0.11"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using SciPyDiffEq
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(SciPyDiffEq)
+end
+
+@testset "JET" begin
+    JET.test_package(SciPyDiffEq; target_defined_modules = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,71 +2,80 @@ using SciPyDiffEq
 using SciPyDiffEq: ODEProblem, solve
 using SciMLBase: successful_retcode
 using Test
-using ExplicitImports
 
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(SciPyDiffEq) === nothing
-    @test check_no_stale_explicit_imports(SciPyDiffEq) === nothing
+const GROUP = get(ENV, "GROUP", "All")
+
+if GROUP == "All" || GROUP == "Core"
+    using ExplicitImports
+
+    @testset "ExplicitImports" begin
+        @test check_no_implicit_imports(SciPyDiffEq) === nothing
+        @test check_no_stale_explicit_imports(SciPyDiffEq) === nothing
+    end
+
+    @testset "SciPy Solvers" begin
+
+        function lorenz(u, p, t)
+            du1 = 10.0(u[2] - u[1])
+            du2 = u[1] * (28.0 - u[3]) - u[2]
+            du3 = u[1] * u[2] - (8 / 3) * u[3]
+            [du1, du2, du3]
+        end
+        u0 = [1.0; 0.0; 0.0]
+        tspan = (0.0, 100.0)
+        prob = ODEProblem(lorenz, u0, tspan)
+        sol = solve(prob, SciPyDiffEq.RK45())
+        @test successful_retcode(sol)
+        sol = solve(prob, SciPyDiffEq.RK23())
+        @test successful_retcode(sol)
+        sol = solve(prob, SciPyDiffEq.Radau())
+        @test successful_retcode(sol)
+        sol = solve(prob, SciPyDiffEq.BDF())
+        @test successful_retcode(sol)
+        sol = solve(prob, SciPyDiffEq.LSODA())
+        @test successful_retcode(sol)
+        sol = solve(prob, SciPyDiffEq.odeint())
+        @test successful_retcode(sol)
+
+        function lorenz(du, u, p, t)
+            du[1] = 10.0(u[2] - u[1])
+            du[2] = u[1] * (28.0 - u[3]) - u[2]
+            du[3] = u[1] * u[2] - (8 / 3) * u[3]
+        end
+        u0 = [1.0; 0.0; 0.0]
+        tspan = (0.0, 100.0)
+        prob = ODEProblem(lorenz, u0, tspan)
+        sol = solve(prob, SciPyDiffEq.RK45())
+        @test successful_retcode(sol)
+        sol(4.0)
+        sol = solve(prob, SciPyDiffEq.RK23())
+        @test successful_retcode(sol)
+        sol(4.0)
+        sol = solve(prob, SciPyDiffEq.Radau())
+        @test successful_retcode(sol)
+        sol(4.0)
+        sol = solve(prob, SciPyDiffEq.BDF())
+        @test successful_retcode(sol)
+        sol(4.0)
+        sol = solve(prob, SciPyDiffEq.LSODA())
+        @test successful_retcode(sol)
+        sol(4.0)
+        sol = solve(prob, SciPyDiffEq.odeint())
+        @test successful_retcode(sol)
+        sol(4.0)
+
+        #using Plots; plot(sol,vars=(1,2,3))
+
+    end # @testset "SciPy Solvers"
+
+    @testset "odeint retcode with dense saveat" begin
+        f(u, p, t) = 1.01 * u
+        prob = ODEProblem(f, [1.0], (0.0, 1.0))
+        sol = solve(prob, SciPyDiffEq.odeint(); saveat = 0.1)
+        @test successful_retcode(sol)
+    end
 end
 
-@testset "SciPy Solvers" begin
-
-    function lorenz(u, p, t)
-        du1 = 10.0(u[2] - u[1])
-        du2 = u[1] * (28.0 - u[3]) - u[2]
-        du3 = u[1] * u[2] - (8 / 3) * u[3]
-        [du1, du2, du3]
-    end
-    u0 = [1.0; 0.0; 0.0]
-    tspan = (0.0, 100.0)
-    prob = ODEProblem(lorenz, u0, tspan)
-    sol = solve(prob, SciPyDiffEq.RK45())
-    @test successful_retcode(sol)
-    sol = solve(prob, SciPyDiffEq.RK23())
-    @test successful_retcode(sol)
-    sol = solve(prob, SciPyDiffEq.Radau())
-    @test successful_retcode(sol)
-    sol = solve(prob, SciPyDiffEq.BDF())
-    @test successful_retcode(sol)
-    sol = solve(prob, SciPyDiffEq.LSODA())
-    @test successful_retcode(sol)
-    sol = solve(prob, SciPyDiffEq.odeint())
-    @test successful_retcode(sol)
-
-    function lorenz(du, u, p, t)
-        du[1] = 10.0(u[2] - u[1])
-        du[2] = u[1] * (28.0 - u[3]) - u[2]
-        du[3] = u[1] * u[2] - (8 / 3) * u[3]
-    end
-    u0 = [1.0; 0.0; 0.0]
-    tspan = (0.0, 100.0)
-    prob = ODEProblem(lorenz, u0, tspan)
-    sol = solve(prob, SciPyDiffEq.RK45())
-    @test successful_retcode(sol)
-    sol(4.0)
-    sol = solve(prob, SciPyDiffEq.RK23())
-    @test successful_retcode(sol)
-    sol(4.0)
-    sol = solve(prob, SciPyDiffEq.Radau())
-    @test successful_retcode(sol)
-    sol(4.0)
-    sol = solve(prob, SciPyDiffEq.BDF())
-    @test successful_retcode(sol)
-    sol(4.0)
-    sol = solve(prob, SciPyDiffEq.LSODA())
-    @test successful_retcode(sol)
-    sol(4.0)
-    sol = solve(prob, SciPyDiffEq.odeint())
-    @test successful_retcode(sol)
-    sol(4.0)
-
-    #using Plots; plot(sol,vars=(1,2,3))
-
-end # @testset "SciPy Solvers"
-
-@testset "odeint retcode with dense saveat" begin
-    f(u, p, t) = 1.01 * u
-    prob = ODEProblem(f, [1.0], (0.0, 1.0))
-    sol = solve(prob, SciPyDiffEq.odeint(); saveat = 0.1)
-    @test successful_retcode(sol)
+if GROUP == "QA"
+    include(joinpath(@__DIR__, "qa", "qa.jl"))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,11 @@ using SciPyDiffEq
 using SciPyDiffEq: ODEProblem, solve
 using SciMLBase: successful_retcode
 using Test
+using ExplicitImports
 
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
-    using ExplicitImports
-
     @testset "ExplicitImports" begin
         @test check_no_implicit_imports(SciPyDiffEq) === nothing
         @test check_no_stale_explicit_imports(SciPyDiffEq) === nothing

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root test workflow to the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, moving the test matrix into a root `test/test_groups.toml`.

- **`.github/workflows/CI.yml`**: replaced the hand-maintained `group × version` matrix job (which called `tests.yml@v1`) with the thin `grouped-tests.yml@v1` caller. `on:` and `concurrency:` preserved verbatim; filename and `name: CI` kept. No `with:` needed — runtests.jl reads the default `GROUP` env var, `check-bounds` stays at the default `yes`, coverage stays on, and the package needs no apt packages.
- **`test/test_groups.toml`** (new): `[Core]` on `["lts", "1", "pre"]`, `[QA]` on `["lts", "1"]`.
- **`test/runtests.jl`**: added `GROUP` dispatch. The existing suite (ExplicitImports + SciPy Solvers + odeint saveat) runs under `All`/`Core`; `QA` includes `test/qa/qa.jl`. Test bodies are unchanged.
- **`test/qa/`** (new): isolated QA environment (`Aqua` + `JET` + `Test` + path-sourced `SciPyDiffEq`) running `Aqua.test_all(SciPyDiffEq)` and `JET.test_package(SciPyDiffEq; target_defined_modules=true)`.
- **`Project.toml`**: added `[compat] Test = "1"` so every `[extras]` dependency carries a compat entry; `julia` compat already at the `1.10` LTS floor (unchanged).

Linux-only package, so no `os` axis.

## Matrix match

Old `CI.yml` matrix: `Core × {1, lts, pre}` on `ubuntu-latest` (Linux only).

The new `test/test_groups.toml`, run through `compute_affected_sublibraries.jl --root-matrix`, emits:

- `Core` × `{lts, 1, pre}` on `ubuntu-latest` — **reproduces the old matrix exactly**.
- `QA` × `{lts, 1}` on `ubuntu-latest` — **newly wired** (new QA group).

QA group newly wired; Aqua/JET run in CI — any failures will be triaged in follow-up.

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)