### PR TITLE
ci: provision scipy for the grouped-tests caller (python3-scipy)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,4 +12,10 @@ concurrency:
 jobs:
   tests:
     uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
+    with:
+      # PyCall builds against the runner's system python3; `using SciPyDiffEq`
+      # then resolves scipy via pyimport_conda, which falls back to a plain
+      # pyimport here (PyCall is not Conda-managed). Install scipy into that
+      # system python so the import succeeds.
+      apt-packages: "python3-scipy"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

CI (Core + Downgrade) fails at `using SciPyDiffEq` with:

```
PyError ... ModuleNotFoundError: No module named scipy
```

### Root cause

The pre-conversion `CI.yml` set `PYTHON: ''` on the `julia-actions/julia-buildpkg` step:

```yaml
- uses: julia-actions/julia-buildpkg@v1
  env:
    PYTHON: ''
```

That bound PyCall to a **Conda.jl-managed Python**. At load time, `SciPyDiffEq.__init__` calls

```julia
pyimport_conda("scipy.integrate", "scipy", "conda-forge")
```

which, on a Conda-managed PyCall, **auto-installs scipy from conda-forge**. That `PYTHON: ''` step is how the old workflow provisioned scipy (added in `746e5f0` "Use Conda Python", Dec 2020).

The conversion to `grouped-tests.yml@v1` (PR #60) dropped that env. The reusable `tests.yml` runs `julia-buildpkg` with no `PYTHON`, so PyCall now builds against the runner's **system python3** (`PyCall.conda == false`). On a non-Conda PyCall, `pyimport_conda` degrades to a plain `pyimport`, which cannot install anything and fails because the runner's python3 has no scipy.

## Fix

Use the `apt-packages` input the reusable workflow already exposes to install scipy into the system python3 PyCall builds against:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    with:
      apt-packages: "python3-scipy"
    secrets: "inherit"
```

No test logic touched.

## Verification (local)

Reproduced the centralized-workflow scenario locally with PyCall bound to system python3 (`PYTHON=/usr/bin/python3`, `PyCall.conda == false`):

- Without scipy in that python: reproduces the exact CI failure (`PyError ... could not be found by pyimport ... did not install scipy`).
- With scipy present (what `python3-scipy` provides): `using SciPyDiffEq` loads, and all six solvers (`RK45`, `RK23`, `Radau`, `BDF`, `LSODA`, `odeint`) run with `successful_retcode`.

## Known limitation — Downgrade still red

This PR fixes **CI.yml only**. The `Downgrade.yml` caller cannot be fixed the same way: the reusable `SciML/.github/.github/workflows/downgrade.yml@v1` exposes **no `apt-packages` (or `container`) input**, so the caller has no hook to provision system packages, and the workflow runs `julia-buildpkg` with no `PYTHON` either.

Fixing Downgrade requires a separate, follow-up change in `SciML/.github`: add an `apt-packages` input to `downgrade.yml` (mirroring `tests.yml`), release it so `@v1` advances, then pass `apt-packages: "python3-scipy"` from this repo's `Downgrade.yml`. Tracking that as a follow-up rather than bundling a shared-infra change here.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)