### PR TITLE
Downgrade: provision scipy (apt) now that downgrade.yml@v1 supports apt-packages

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -22,4 +22,9 @@ jobs:
       group: "${{ matrix.group }}"
       julia-version: "lts"
       skip: "Pkg,TOML"
+      # PyCall builds against the runner's system python3; `using SciPyDiffEq`
+      # then resolves scipy via pyimport_conda, which falls back to a plain
+      # pyimport here (PyCall is not Conda-managed). Install scipy into that
+      # system python so the import succeeds.
+      apt-packages: "python3-scipy"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The Core test leg was fixed in #61 by passing `apt-packages: "python3-scipy"` to the `grouped-tests.yml@v1` caller in `CI.yml`. However, the **Downgrade** leg still fails with `No module named scipy` because `Downgrade.yml` never provisioned scipy onto the runner's system python3.

PyCall builds against the runner's system python3; `using SciPyDiffEq` then resolves scipy via `pyimport_conda`, which falls back to a plain `pyimport` here (PyCall is not Conda-managed). Without scipy installed into that system python, the import fails.

## Fix

As of SciML/.github **v1.13**, the reusable `downgrade.yml@v1` workflow supports an `apt-packages` input. This PR passes `apt-packages: "python3-scipy"` to the Downgrade caller, mirroring what #61 did for the Core/grouped-tests leg.

Only the workflow config file (`.github/workflows/Downgrade.yml`) is touched; no test logic changed. `actionlint` is clean.

Ignore until reviewed by @ChrisRackauckas.