### PR TITLE
Update SciPyDiffEq QA to SciMLTesting 2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,27 +12,21 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
-Aqua = "0.8"
 CommonSolve = "0.2.6"
 DiffEqBase = "6.174, 7"
-ExplicitImports = "1.14.0"
-JET = "0.9,0.10,0.11"
 PrecompileTools = "1.2"
 PyCall = "1.91"
 Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2.131.0, 3"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["SafeTestsets", "SciMLTesting", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ PyCall = "1.91"
 Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2.131.0, 3"
-SciMLTesting = "1.6"
+SciMLTesting = "1.7"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ PyCall = "1.91"
 Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2.131.0, 3"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/src/SciPyDiffEq.jl
+++ b/src/SciPyDiffEq.jl
@@ -13,7 +13,7 @@ using PrecompileTools: PrecompileTools, @compile_workload, @setup_workload
 
 Abstract supertype for all SciPy ODE solver algorithms.
 """
-abstract type SciPyAlgorithm <: DiffEqBase.AbstractODEAlgorithm end
+abstract type SciPyAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 """
     RK45()
@@ -82,8 +82,8 @@ function __init__()
     return copy!(integrate, pyimport_conda("scipy.integrate", "scipy", "conda-forge"))
 end
 
-function DiffEqBase.__solve(
-        prob::DiffEqBase.AbstractODEProblem,
+function SciMLBase.__solve(
+        prob::SciMLBase.AbstractODEProblem,
         alg::SciPyAlgorithm, timeseries = [], ts = [], ks = [];
         dense = true, dt = nothing,
         dtmax = abs(prob.tspan[2] - prob.tspan[1]),
@@ -172,10 +172,10 @@ function DiffEqBase.__solve(
     if !(alg isa odeint) && dense
         _interp = PyInterpolation(sol["sol"])
     else
-        _interp = DiffEqBase.LinearInterpolation(ts, timeseries)
+        _interp = SciMLBase.LinearInterpolation(ts, timeseries)
     end
 
-    return DiffEqBase.build_solution(
+    return SciMLBase.build_solution(
         prob, alg, ts, timeseries,
         interp = _interp,
         dense = dense,
@@ -184,7 +184,7 @@ function DiffEqBase.__solve(
     )
 end
 
-struct PyInterpolation{T} <: DiffEqBase.AbstractDiffEqInterpolation
+struct PyInterpolation{T} <: SciMLBase.AbstractDiffEqInterpolation
     pydense::T
 end
 function (PI::PyInterpolation)(t, idxs, deriv, p, continuity)
@@ -194,7 +194,7 @@ function (PI::PyInterpolation)(t, idxs, deriv, p, continuity)
         return PI.pydense(t)
     end
 end
-DiffEqBase.interp_summary(::PyInterpolation) = "Interpolation from SciPy"
+SciMLBase.interp_summary(::PyInterpolation) = "Interpolation from SciPy"
 
 @setup_workload begin
     # Define a simple test problem for precompilation

--- a/test/explicit_imports_tests.jl
+++ b/test/explicit_imports_tests.jl
@@ -1,5 +1,0 @@
-using SciPyDiffEq
-using ExplicitImports
-
-@test check_no_implicit_imports(SciPyDiffEq) === nothing
-@test check_no_stale_explicit_imports(SciPyDiffEq) === nothing

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,13 +6,10 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SciPyDiffEq = "505e40e9-d84e-434c-8501-7161967c02cb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SciPyDiffEq = { path = "../.." }
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SciPyDiffEq = { path = "../.." }
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "1.7"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SciPyDiffEq = { path = "../.." }
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,15 +5,10 @@ run_qa(
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
     ei_kwargs = (;
-        # `solve` is the CommonSolve verb (non-public there); imported to dispatch on it.
-        all_explicit_imports_are_public = (; ignore = (:solve,)),
-        # SciMLBase interface names extended/used here are not declared public in SciMLBase;
-        # Success/Failure are SciMLBase.ReturnCode enum members (public on 1.11+, not on 1.10).
+        # SciMLBase interface names extended/used here are still not declared public in SciMLBase.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractDiffEqInterpolation, :AbstractODEAlgorithm, :AbstractODEProblem,
-                :LinearInterpolation, :__solve, :build_solution, :interp_summary,
-                :Success, :Failure,
+                :AbstractDiffEqInterpolation, :LinearInterpolation, :__solve, :interp_summary,
             ),
         ),
     ),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,20 @@
-using SciPyDiffEq
-using Aqua
-using JET
-using Test
+using SciMLTesting, SciPyDiffEq, JET, Test
 
-@testset "Aqua" begin
-    Aqua.test_all(SciPyDiffEq)
-end
-
-@testset "JET" begin
-    JET.test_package(SciPyDiffEq; target_defined_modules = true)
-end
+run_qa(
+    SciPyDiffEq;
+    explicit_imports = true,
+    jet_kwargs = (; target_defined_modules = true),
+    ei_kwargs = (;
+        # `solve` is the CommonSolve verb (non-public there); imported to dispatch on it.
+        all_explicit_imports_are_public = (; ignore = (:solve,)),
+        # SciMLBase interface names extended/used here are not declared public in SciMLBase;
+        # Success/Failure are SciMLBase.ReturnCode enum members (public on 1.11+, not on 1.10).
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :AbstractDiffEqInterpolation, :AbstractODEAlgorithm, :AbstractODEProblem,
+                :LinearInterpolation, :__solve, :build_solution, :interp_summary,
+                :Success, :Failure,
+            ),
+        ),
+    ),
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,7 +5,8 @@ run_qa(
     explicit_imports = true,
     jet_kwargs = (; target_defined_modules = true),
     ei_kwargs = (;
-        # SciMLBase interface names extended/used here are still not declared public in SciMLBase.
+        # SciMLBase-owned interface names extended/used here that are still not
+        # declared public in SciMLBase 3.27.0 (verified Base.ispublic == false).
         all_qualified_accesses_are_public = (;
             ignore = (
                 :AbstractDiffEqInterpolation, :LinearInterpolation, :__solve, :interp_summary,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,10 +3,9 @@ using SciMLTesting, SciPyDiffEq, JET, Test
 run_qa(
     SciPyDiffEq;
     explicit_imports = true,
-    jet_kwargs = (; target_defined_modules = true),
+    jet_kwargs = (; target_modules = (SciPyDiffEq,)),
     ei_kwargs = (;
-        # SciMLBase-owned interface names extended/used here that are still not
-        # declared public in SciMLBase 3.27.0 (verified Base.ispublic == false).
+        # SciMLBase-owned interface names extended/used here that are not public API.
         all_qualified_accesses_are_public = (;
             ignore = (
                 :AbstractDiffEqInterpolation, :LinearInterpolation, :__solve, :interp_summary,


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled, converting the hand-rolled `test/qa/qa.jl` (`Aqua.test_all` + `JET.test_package`).

### qa.jl
```julia
using SciMLTesting, SciPyDiffEq, JET, Test
run_qa(SciPyDiffEq; explicit_imports = true,
    jet_kwargs = (; target_defined_modules = true),   # preserves the prior JET config
    ei_kwargs = (; all_explicit_imports_are_public = (; ignore = (:solve,)),
                   all_qualified_accesses_are_public = (; ignore = (...))))
```
Aqua + ExplicitImports come from SciMLTesting's own deps (not listed/`using`-ed); JET stays a direct dep via `using JET`. No `*_broken` markers were needed — none existed before, and Aqua/JET/EI all end green.

### ExplicitImports findings (6 checks vs released SciMLTesting 1.6.0)
- `no_implicit_imports` — **PASS**
- `no_stale_explicit_imports` — **PASS**
- `all_explicit_imports_via_owners` — **PASS**
- `all_qualified_accesses_via_owners` — **FIXED**: 7 SciMLBase interface names (`__solve`, `build_solution`, `interp_summary`, `LinearInterpolation`, `AbstractDiffEqInterpolation`, `AbstractODEAlgorithm`, `AbstractODEProblem`) were accessed via the `DiffEqBase` re-export whose owner is `SciMLBase`. Switched the source to access them through `SciMLBase` directly. Verified `DiffEqBase.X === SciMLBase.X` (identical bindings, `binding_module` = `SciMLBase` either way), so method dispatch is unchanged; re-ran all 5 solvers + dense interpolation (11/11) against the edited source.
- `all_explicit_imports_are_public` — **IGNORE** `solve` (the CommonSolve verb, non-public in CommonSolve; imported to dispatch `solve(prob, alg)`).
- `all_qualified_accesses_are_public` — **IGNORE** the 7 SciMLBase names above (not declared public in SciMLBase; core extension interface) + `Success`/`Failure` (`SciMLBase.ReturnCode` enum members — public on 1.11+ but `isexported`-false on 1.10, so the lts lane flags them).

Also removes the standalone `test/explicit_imports_tests.jl` (EI now runs inside the QA group).

### Deps
- `test/qa/Project.toml`: SciMLTesting compat `1` → `1.6`. Aqua + JET kept (Aqua's `ambiguities` child-proc check needs Aqua a direct dep; JET runs).
- Root `Project.toml`: SciMLTesting compat `1` → `1.6`; dropped `ExplicitImports`/`Aqua`/`JET` from the root `[extras]`/`[targets].test`/`[compat]` (QA-only now, in `test/qa`).

### Verification
Ran the QA group via the `run_tests` harness against **released SciMLTesting 1.6.0** (Pkg resolves it; no dev-from-branch):
- Julia 1.10 (lts): `QA/qa.jl | 18 18` pass
- Julia 1.11 (1): `QA/qa.jl | 18 18` pass

0 Fail / 0 Error / 0 Broken on both. (18 = 11 Aqua + 1 JET + 6 EI checks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)