### PR TITLE
Release prep: bump version to 0.2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciPyDiffEq"
 uuid = "505e40e9-d84e-434c-8501-7161967c02cb"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

The last registered version is 0.2.7 (git-tree-sha1 `35c0d81ccf68c3209ec8dabf6898610ead3593c1`, matching commit 65ac722). Since then, one commit has landed on `master` without a version bump:

- 8c7944c — "Update SciPyDiffEq QA to SciMLTesting 2.1 (#65)"

### What changed since 0.2.7

- QA tooling migrated from hand-rolled `Aqua.test_all` + `JET.test_package` to SciMLTesting's `run_qa` helper (SciMLTesting compat bumped 1 -> 2.1 in the test target).
- `test/explicit_imports_tests.jl` removed (ExplicitImports checks now run inside the QA group instead).
- `test/qa/Project.toml` no longer uses a `[sources]` path override.
- In `src/SciPyDiffEq.jl`, internal extension points (`__solve`, `build_solution`, `interp_summary`, `AbstractDiffEqInterpolation`, `LinearInterpolation`, `AbstractODEAlgorithm`, `AbstractODEProblem`) are now qualified via their owning module `SciMLBase` instead of via the `DiffEqBase` re-export. Per the commit message, this was verified locally (`DiffEqBase.X === SciMLBase.X` for every renamed symbol), so dispatch/behavior is unchanged — this is a qualification-only refactor to satisfy ExplicitImports public-API checks, not a behavior or public-API change.

### Bump type: PATCH (0.2.7 -> 0.2.8)

No new exported/public API and no behavior change — the only source-level change swaps which (already-identical) module a handful of internal, non-exported symbols are qualified through, and the rest of the diff is test/QA-only. This qualifies as a patch-level change per the QA/test/internal-refactor default.

### Compat bounds

Left untouched. Checked `SciMLBase` at the current lower bound `2.131.0`: it already defines `AbstractDiffEqInterpolation`, `LinearInterpolation`, `interp_summary`, `__solve`, and `AbstractODEAlgorithm`/`AbstractODEProblem` in `src/interpolation.jl` and `src/SciMLBase.jl`, so no runtime dep needs a wider lower bound for this change. `SciMLTesting` is a test-only `extra`/`target` dep (not a runtime `[deps]` entry), and its compat was already updated to `"2.1"` as part of the diff being released here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)