### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,10 @@ using SciMLTesting, SciPyDiffEq, JET, Test
 
 run_qa(
     SciPyDiffEq;
+    api_docs_kwargs = (;
+        rendered = true,
+        rendered_ignore = Tuple(names(SciPyDiffEq.DiffEqBase)),
+    ),
     explicit_imports = true,
     jet_kwargs = (; target_modules = (SciPyDiffEq,)),
     ei_kwargs = (;


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Enables SciMLTesting rendered public API docs coverage for SciPyDiffEq.
- Ignores DiffEqBase-owned reexports for rendered coverage. SciPyDiffEq has no package-owned `export`, Julia `public`, or `@public` declarations on current `master`.
- Does not add docs, docstrings, `[sources]`, or package path source entries.

## Validation

- `git diff --check`: passed.
- `TESTING_GROUP=QA BACKEND_GROUP=CPU /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e "using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)"`: passed core tests (`odeint_saveat_tests.jl` 1/1, `scipy_solvers_tests.jl` 12/12).
- Direct QA with Julia `+1.10`: `julia --project=test/qa -e "using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")"`: `Quality Assurance | 18 pass | 18 total`.
- Runic v1.7.0 `--check src test`: passed.
