### PR TITLE
Use inherited public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,10 +2,6 @@ using SciMLTesting, SciPyDiffEq, JET, Test
 
 run_qa(
     SciPyDiffEq;
-    api_docs_kwargs = (;
-        rendered = true,
-        rendered_ignore = Tuple(names(SciPyDiffEq.DiffEqBase)),
-    ),
     explicit_imports = true,
     jet_kwargs = (; target_modules = (SciPyDiffEq,)),
     ei_kwargs = (;


### PR DESCRIPTION
Removes the package-specific DiffEqBase rendered-doc ignore list. Inherited public bindings are verified at their defining package by SciMLTesting #27.

Depends on https://github.com/SciML/SciMLTesting.jl/pull/27.

Ignore until reviewed by @ChrisRackauckas.