### PR TITLE
Adopt strict SciMLTesting 2.4 QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /Manifest.toml
 /dev/
+docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciPyDiffEq"
 uuid = "505e40e9-d84e-434c-8501-7161967c02cb"
-version = "0.2.8"
+version = "0.3.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -8,18 +8,18 @@ CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 
 [compat]
 CommonSolve = "0.2.6"
 DiffEqBase = "6.174, 7"
 PrecompileTools = "1.2"
 PyCall = "1.91"
-Reexport = "1.0"
 SafeTestsets = "0.1, 1"
 SciMLBase = "2.131.0, 3"
-SciMLTesting = "2.1"
+SciMLPublic = "1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ SciPyDiffEq.odeint
 ## Example
 
 ```julia
+using CommonSolve: solve
+using SciMLBase: ODEProblem
 using SciPyDiffEq
 
 function lorenz(u,p,t)
@@ -62,7 +64,10 @@ In the following we can measure the overhead and show that using SciPy from Juli
 is about 3x faster than using SciPy with Numba. Using SciPyDiffEq:
 
 ```julia
-using SciPyDiffEq, BenchmarkTools
+using BenchmarkTools
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+using SciPyDiffEq
 
 function lorenz(u,p,t)
     du1 = 10.0(u[2]-u[1])

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SciPyDiffEq = "505e40e9-d84e-434c-8501-7161967c02cb"
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,14 @@
+using Documenter
+using SciPyDiffEq
+
+makedocs(
+    modules = [SciPyDiffEq],
+    sitename = "SciPyDiffEq.jl",
+    checkdocs = :all,
+    doctest = true,
+    linkcheck = true,
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md",
+    ],
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,11 @@
+# API
+
+```@docs
+SciPyDiffEq.SciPyAlgorithm
+SciPyDiffEq.RK45
+SciPyDiffEq.RK23
+SciPyDiffEq.Radau
+SciPyDiffEq.BDF
+SciPyDiffEq.LSODA
+SciPyDiffEq.odeint
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,14 @@
+# SciPyDiffEq.jl
+
+SciPyDiffEq.jl exposes SciPy's ordinary differential equation solvers through the
+SciML common solve interface. Construct problems with `SciMLBase` and call
+`CommonSolve.solve` with an algorithm from this package.
+
+```julia
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+using SciPyDiffEq: RK45
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, RK45())
+```

--- a/src/SciPyDiffEq.jl
+++ b/src/SciPyDiffEq.jl
@@ -1,17 +1,32 @@
 module SciPyDiffEq
 
-using Reexport: @reexport
-using DiffEqBase: DiffEqBase, ReturnCode
-@reexport using DiffEqBase
-using SciMLBase: SciMLBase, ODEProblem
 using CommonSolve: solve
-using PyCall: PyCall, PyNULL, pyimport, pyimport_conda
-using PrecompileTools: PrecompileTools, @compile_workload, @setup_workload
+using DiffEqBase: ReturnCode, isinplace
+import SciMLBase
+import SciMLBase: __solve, interp_summary
+using SciMLBase: AbstractDiffEqInterpolation, LinearInterpolation, ODEProblem
+using SciMLPublic: @public
+using PyCall: PyNULL, pyimport, pyimport_conda
+using PrecompileTools: @compile_workload, @setup_workload
+
+@public SciPyAlgorithm, RK45, RK23, Radau, BDF, LSODA, odeint
 
 """
     SciPyAlgorithm
 
 Abstract supertype for all SciPy ODE solver algorithms.
+
+Use a concrete subtype as the algorithm argument to `solve`.
+
+# Example
+
+```julia
+using CommonSolve: solve
+using SciMLBase: ODEProblem
+
+prob = ODEProblem((u, p, t) -> -u, 1.0, (0.0, 1.0))
+sol = solve(prob, RK45())
+```
 """
 abstract type SciPyAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
@@ -20,6 +35,12 @@ abstract type SciPyAlgorithm <: SciMLBase.AbstractODEAlgorithm end
 
 Explicit Runge-Kutta method of order 5(4) from SciPy. This is the Dormand-Prince
 method, suitable for non-stiff problems.
+
+# Example
+
+```julia
+sol = solve(prob, RK45())
+```
 
 See also: [`RK23`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
 """
@@ -31,6 +52,12 @@ struct RK45 <: SciPyAlgorithm end
 Explicit Runge-Kutta method of order 3(2) from SciPy. Suitable for non-stiff
 problems with lower accuracy requirements.
 
+# Example
+
+```julia
+sol = solve(prob, RK23())
+```
+
 See also: [`RK45`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
 """
 struct RK23 <: SciPyAlgorithm end
@@ -40,6 +67,12 @@ struct RK23 <: SciPyAlgorithm end
 
 Implicit Runge-Kutta method of the Radau IIA family of order 5 from SciPy.
 Suitable for stiff problems.
+
+# Example
+
+```julia
+sol = solve(prob, Radau())
+```
 
 See also: [`RK45`](@ref), [`RK23`](@ref), [`BDF`](@ref), [`LSODA`](@ref)
 """
@@ -51,6 +84,12 @@ struct Radau <: SciPyAlgorithm end
 Implicit multi-step variable-order (1 to 5) method based on backward
 differentiation formulas from SciPy. Suitable for stiff problems.
 
+# Example
+
+```julia
+sol = solve(prob, BDF())
+```
+
 See also: [`RK45`](@ref), [`RK23`](@ref), [`Radau`](@ref), [`LSODA`](@ref)
 """
 struct BDF <: SciPyAlgorithm end
@@ -60,6 +99,12 @@ struct BDF <: SciPyAlgorithm end
 
 Adams/BDF method with automatic stiffness detection and switching from SciPy.
 Originally from the FORTRAN library ODEPACK.
+
+# Example
+
+```julia
+sol = solve(prob, LSODA())
+```
 
 See also: [`RK45`](@ref), [`RK23`](@ref), [`Radau`](@ref), [`BDF`](@ref), [`odeint`](@ref)
 """
@@ -72,6 +117,12 @@ SciPy's `odeint` function, which wraps the FORTRAN solver LSODA from ODEPACK.
 This is the legacy SciPy interface. Note that `saveat` is required when using
 this algorithm.
 
+# Example
+
+```julia
+sol = solve(prob, odeint(); saveat = 0.1)
+```
+
 See also: [`LSODA`](@ref), [`RK45`](@ref), [`BDF`](@ref)
 """
 struct odeint <: SciPyAlgorithm end
@@ -82,7 +133,7 @@ function __init__()
     return copy!(integrate, pyimport_conda("scipy.integrate", "scipy", "conda-forge"))
 end
 
-function SciMLBase.__solve(
+function __solve(
         prob::SciMLBase.AbstractODEProblem,
         alg::SciPyAlgorithm, timeseries = [], ts = [], ks = [];
         dense = true, dt = nothing,
@@ -96,7 +147,7 @@ function SciMLBase.__solve(
     tspan = prob.tspan
     u0 = prob.u0
 
-    if DiffEqBase.isinplace(prob)
+    if isinplace(prob)
         f = function (t, u)
             du = similar(u)
             prob.f(du, u, p, t)
@@ -172,7 +223,7 @@ function SciMLBase.__solve(
     if !(alg isa odeint) && dense
         _interp = PyInterpolation(sol["sol"])
     else
-        _interp = SciMLBase.LinearInterpolation(ts, timeseries)
+        _interp = LinearInterpolation(ts, timeseries)
     end
 
     return SciMLBase.build_solution(
@@ -184,7 +235,7 @@ function SciMLBase.__solve(
     )
 end
 
-struct PyInterpolation{T} <: SciMLBase.AbstractDiffEqInterpolation
+struct PyInterpolation{T} <: AbstractDiffEqInterpolation
     pydense::T
 end
 function (PI::PyInterpolation)(t, idxs, deriv, p, continuity)
@@ -194,7 +245,7 @@ function (PI::PyInterpolation)(t, idxs, deriv, p, continuity)
         return PI.pydense(t)
     end
 end
-SciMLBase.interp_summary(::PyInterpolation) = "Interpolation from SciPy"
+interp_summary(::PyInterpolation) = "Interpolation from SciPy"
 
 @setup_workload begin
     # Define a simple test problem for precompilation

--- a/test/odeint_saveat_tests.jl
+++ b/test/odeint_saveat_tests.jl
@@ -1,5 +1,6 @@
 using SciPyDiffEq
-using SciPyDiffEq: ODEProblem, solve
+using CommonSolve: solve
+using SciMLBase: ODEProblem
 using SciMLBase: successful_retcode
 using Test
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SciPyDiffEq = "505e40e9-d84e-434c-8501-7161967c02cb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
-Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,15 +1,3 @@
-using SciMLTesting, SciPyDiffEq, JET, Test
+using SciMLTesting, SciPyDiffEq
 
-run_qa(
-    SciPyDiffEq;
-    explicit_imports = true,
-    jet_kwargs = (; target_modules = (SciPyDiffEq,)),
-    ei_kwargs = (;
-        # SciMLBase-owned interface names extended/used here that are not public API.
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                :AbstractDiffEqInterpolation, :LinearInterpolation, :__solve, :interp_summary,
-            ),
-        ),
-    ),
-)
+run_qa(SciPyDiffEq)

--- a/test/scipy_solvers_tests.jl
+++ b/test/scipy_solvers_tests.jl
@@ -1,5 +1,6 @@
 using SciPyDiffEq
-using SciPyDiffEq: ODEProblem, solve
+using CommonSolve: solve
+using SciMLBase: ODEProblem
 using SciMLBase: successful_retcode
 using Test
 


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Changes
- Require SciMLTesting 2.4 and use the plain strict `run_qa(SciPyDiffEq)` invocation.
- Remove the blanket DiffEqBase reexport; SciPyDiffEq owns and documents only its solver algorithm API.
- Use direct public APIs from SciMLBase, CommonSolve, and DiffEqBase.
- Add rendered Documenter API docs and definition-site usage examples.
- Bump to 0.3.0 because removing the blanket reexport is a pre-1.0 breaking API change.

## Validation
- Julia 1.12 `Pkg.test()`
- strict SciMLTesting 2.4 QA
- Documenter doctests, checkdocs, rendered API docs, and link checking
- Runic 1.7 and `git diff --check`

Julia 1.10 local `Pkg.test()` fails identically on clean master before assertions because the local Conda SciPy build requires a newer CXXABI. Tracked separately in #70; CI uses system Python and SciPy.