### PR TITLE
Drop older SciML major versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 
 [compat]
 CommonSolve = "0.2.6"
-DiffEqBase = "6.174, 7"
+DiffEqBase = "7"
 PrecompileTools = "1.2"
 PyCall = "1.91"
 SafeTestsets = "0.1, 1"
-SciMLBase = "2.131.0, 3"
+SciMLBase = "3"
 SciMLPublic = "1"
 SciMLTesting = "2.4"
 Test = "1"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop older major versions of SciML packages**. For each SciML dependency, only the current major remains (existing lower bound on that major is kept). No code, tests, or package version were changed.

- `Project.toml` [deps] `DiffEqBase`: `6.174, 7` → `7` (drop 6.174; current SciML major is 7)
- `Project.toml` [deps] `SciMLBase`: `2.131.0, 3` → `3` (drop 2.131.0; current SciML major is 3)

## Why

Supporting multiple SciML majors keeps untested resolver windows. The current major is the one in the General registry; older majors are dropped even when that current major is recent.

## Verification

Current majors come from JuliaRegistries/General `Versions.toml`. Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
