### PR TITLE
Release SciPyDiffEq 0.2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciPyDiffEq"
 uuid = "505e40e9-d84e-434c-8501-7161967c02cb"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## What changed and why

Bumps SciPyDiffEq from 0.2.9 to 0.2.10 to release the restored, explicitly documented SciML common interface from https://github.com/SciML/SciPyDiffEq.jl/pull/74. This is the next consecutive version and follows the patch-bump policy for restored public API in a 0.x package.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA/qa.jl | 54 passed / 54 total`; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — two Core testsets, 13 passed / 13 total; package tests passed.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
