### PR TITLE
Remove x86 CI lane (Conda i686 unsupported)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,7 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-# PyCall/Conda has no usable i686 build on GHA; keep the lane for signal but non-blocking.
-
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,11 +2,6 @@
 versions = ["lts", "1", "pre"]
 
 # PyCall/Conda has no usable i686 build on GHA; keep the lane for signal but non-blocking.
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- x86 CI fails building PyCall: Conda.jl passes `--satisfied-skip-solve`, which the i686 Anaconda conda binary does not accept; Miniforge also does not support this platform.
- Remove the `Core 32-bit` group until a working 32-bit Python/Conda stack exists.

## Test plan
- [ ] No x86 job scheduled on default-branch CI

Made with [Cursor](https://cursor.com)